### PR TITLE
commands: open docs in default browser

### DIFF
--- a/commands/docs.go
+++ b/commands/docs.go
@@ -2,9 +2,10 @@ package commands
 
 import (
 	"fmt"
-	"os/exec"
+	"log"
 
 	"github.com/codegangsta/cli"
+	"github.com/pkg/browser"
 )
 
 var DocsCMD = cli.Command{
@@ -18,8 +19,8 @@ func docs(c *cli.Context) {
 	fmt.Println("Opening tenet documentation in a new browser window ...")
 	// TODO(waigani) DEMOWARE
 	writeTenetDoc(c, "", "/tmp/tenets.md")
-	cmd := exec.Command("chromium-browser", "/tmp/tenets.md")
-	// cmd.Stdout = &stdout
-	// cmd.Stderr = &stderr
-	cmd.Run()
+	err := browser.OpenFile("/tmp/tenets.md")
+	if err != nil {
+		log.Printf("ERROR opening docs in browser: %v", err)
+	}
 }

--- a/commands/docs.go
+++ b/commands/docs.go
@@ -2,9 +2,9 @@ package commands
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/codegangsta/cli"
+	"github.com/lingo-reviews/tenets/go/dev/tenet/log"
 	"github.com/pkg/browser"
 )
 


### PR DESCRIPTION
Use github.com/pkg/browser to open the docs
in the user's default browser. Should work
on Linux, Windows and OS X.

Fixes #7