### PR TITLE
Make the binary driver use tcp connections on OS X. Fixes #20

### DIFF
--- a/tenet/driver/binary/service.go
+++ b/tenet/driver/binary/service.go
@@ -109,7 +109,11 @@ func dialer() dialerFunc {
 type dialerFunc func(addr string, timeout time.Duration) (net.Conn, error)
 
 func serviceTcpDialer(addr string, timeout time.Duration) (net.Conn, error) {
-	raddr := net.ResolveTCPAddr("tcp", raddr)
+	raddr, err := net.ResolveTCPAddr("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+
 	return net.DialTCP("tcp", nil, raddr)
 }
 

--- a/tenet/driver/binary/service.go
+++ b/tenet/driver/binary/service.go
@@ -98,13 +98,20 @@ func dialer() dialerFunc {
 	switch runtime.GOOS {
 	case "windows":
 		return serviceWindowsDialer
-	case "linux", "darwin", "freebsd":
+	case "linux", "freebsd":
 		return serviceUnixDialer
+	case "darwin":
+		return serviceTcpDialer
 	}
 	return serviceUnixDialer
 }
 
 type dialerFunc func(addr string, timeout time.Duration) (net.Conn, error)
+
+func serviceTcpDialer(addr string, timeout time.Duration) (net.Conn, error) {
+	raddr := net.ResolveTCPAddr("tcp", raddr)
+	return net.DialTCP("tcp", nil, raddr)
+}
 
 func serviceUnixDialer(addr string, timeout time.Duration) (net.Conn, error) {
 	typ := "unix"


### PR DESCRIPTION
This relies on a change in the tenets package that I will be filing shortly, however this code is what made it start running properly for me on my OS X machine.