### PR TITLE
Render tenet docs to HTML

### DIFF
--- a/commands/docs.go
+++ b/commands/docs.go
@@ -1,11 +1,13 @@
 package commands
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/codegangsta/cli"
-	"github.com/lingo-reviews/tenets/go/dev/tenet/log"
+	"github.com/microcosm-cc/bluemonday"
 	"github.com/pkg/browser"
+	"github.com/russross/blackfriday"
 )
 
 var DocsCMD = cli.Command{
@@ -17,10 +19,20 @@ var DocsCMD = cli.Command{
 func docs(c *cli.Context) {
 
 	fmt.Println("Opening tenet documentation in a new browser window ...")
-	// TODO(waigani) DEMOWARE
-	writeTenetDoc(c, "", "/tmp/tenets.md")
-	err := browser.OpenFile("/tmp/tenets.md")
-	if err != nil {
-		log.Printf("ERROR opening docs in browser: %v", err)
+
+	var mdBuf bytes.Buffer
+	if err := writeTenetDoc(c, "", &mdBuf); err != nil {
+		oserrf("%v", err)
+		return
+	}
+
+	// Render markdown to HTML, and sanitise it to protect from
+	// malicious tenets.
+	htmlUnsafe := blackfriday.MarkdownCommon(mdBuf.Bytes())
+	html := bluemonday.UGCPolicy().SanitizeBytes(htmlUnsafe)
+
+	if err := browser.OpenReader(bytes.NewReader(html)); err != nil {
+		oserrf("opening docs in browser: %v", err)
+		return
 	}
 }

--- a/commands/docs.go
+++ b/commands/docs.go
@@ -28,7 +28,7 @@ func docs(c *cli.Context) {
 
 	// Render markdown to HTML, and sanitise it to protect from
 	// malicious tenets.
-	htmlUnsafe := blackfriday.MarkdownCommon(mdBuf.Bytes())
+	htmlUnsafe := blackfriday.MarkdownBasic(mdBuf.Bytes())
 	html := bluemonday.UGCPolicy().SanitizeBytes(htmlUnsafe)
 
 	if err := browser.OpenReader(bytes.NewReader(html)); err != nil {


### PR DESCRIPTION
"lingo docs" will now render the tenet docs
to HTML. Because the content comes from tenets,
and tenets could come from anywhere, we sanitise
the HTML output before presenting to the user.

Also changed "writeTenetDoc" to return errors,
logging in the "writeDoc" top-level command
function. In doing this, I found a data race:
multiple goroutines writing to the same map.
I've changed them to write to pre-sized slice
elements.

Fixes #23