### PR TITLE
command: Remove diff logic

### DIFF
--- a/tenet/driver/remote/service.go
+++ b/tenet/driver/remote/service.go
@@ -1,0 +1,1 @@
+package remote


### PR DESCRIPTION
Whether an issue is inside the diff context is calculated in the tenet. Remove
legacy code which calculated it in the client.